### PR TITLE
[Task 7] ECFG, RSM

### DIFF
--- a/project/__init__.py
+++ b/project/__init__.py
@@ -18,9 +18,3 @@ from project.rpq import *
 
 import project.cfg_utils
 from project.cfg_utils import *
-
-import project.ecfg_utils
-from project.ecfg_utils import *
-
-import project.rsm_utils
-from project.rsm_utils import *

--- a/project/__init__.py
+++ b/project/__init__.py
@@ -15,3 +15,12 @@ from project.boolean_matrices import *
 
 import project.rpq
 from project.rpq import *
+
+import project.cfg_utils
+from project.cfg_utils import *
+
+import project.ecfg_utils
+from project.ecfg_utils import *
+
+import project.rsm_utils
+from project.rsm_utils import *

--- a/project/cfg_utils.py
+++ b/project/cfg_utils.py
@@ -10,11 +10,12 @@ __all__ = [
     "get_wcnf_from_text",
     "is_wcnf",
     "get_original_csg_from_file",
+    "cfg_to_ecfg",
 ]
 
 from pyformlang.regular_expression import Regex
 
-from project import ECFG, ECFGProduction
+from project.ecfg_utils import ECFGProduction, ECFG
 
 
 def get_cnf_from_file(path: str, start_symbol: str = None) -> CFG:

--- a/project/cfg_utils.py
+++ b/project/cfg_utils.py
@@ -1,0 +1,351 @@
+import os
+from typing import AbstractSet
+
+from pyformlang.cfg import CFG, Variable, Production, Epsilon
+
+__all__ = [
+    "get_cnf_from_file",
+    "get_cnf_from_text",
+    "get_wcnf_from_file",
+    "get_wcnf_from_text",
+    "is_wcnf",
+    "get_original_csg_from_file",
+]
+
+from pyformlang.regular_expression import Regex
+
+from project import ECFG, ECFGProduction
+
+
+def get_cnf_from_file(path: str, start_symbol: str = None) -> CFG:
+    """
+    Gets Context Free Grammar in Chomsky Normal Form (a more strict case of
+    the Weak Chomsky Normal Form, which can be weakened to it through product changes)
+    equivalent to file text representation of CFG.
+
+    Parameters
+    ----------
+    path: str
+        A path to file containing text representation of CFG with rules:
+        The structure of a production is: head -> body_1 | body_2 | … | body_n
+        A variable (or non terminal) begins by a capital letter
+        A terminal begins by a non-capital character
+        Terminals and Variables are separated by spaces
+        An epsilon symbol can be represented by epsilon, $, ε, ϵ or Є
+    start_symbol: str, default = None
+        An axiom for CFG
+        If not specified, 'S' will be used
+
+    Returns
+    -------
+    CNF:
+        Context Free Grammar in Chomsky Normal Form equivalent to
+        file text representation of CFG
+    Raises
+    ------
+    OSError:
+        If there was an error while working with file
+    ValueError:
+        If file text is not satisfied to the rules
+    """
+
+    __check_path(path)
+
+    with open(path, "r") as file:
+        cfg_str = file.read()
+
+    return get_cnf_from_text(cfg_str, start_symbol)
+
+
+def get_wcnf_from_file(path: str, start_symbol: str = None) -> CFG:
+    """
+    Gets Context Free Grammar in Weak Chomsky Normal Form
+    equivalent to file text representation of CFG.
+
+    Parameters
+    ----------
+    path: str
+        A path to file containing text representation of CFG with rules:
+        The structure of a production is: head -> body_1 | body_2 | … | body_n
+        A variable (or non terminal) begins by a capital letter
+        A terminal begins by a non-capital character
+        Terminals and Variables are separated by spaces
+        An epsilon symbol can be represented by epsilon, $, ε, ϵ or Є
+    start_symbol: str, default = None
+        An axiom for CFG
+        If not specified, 'S' will be used
+
+    Returns
+    -------
+    CNF:
+        Context Free Grammar in Chomsky Normal Form equivalent to
+        file text representation of CFG
+    Raises
+    ------
+    OSError:
+        If there was an error while working with file
+    ValueError:
+        If file text is not satisfied to the rules
+    """
+
+    __check_path(path)
+
+    with open(path, "r") as file:
+        cfg_str = file.read()
+
+    return get_wcnf_from_text(cfg_str, start_symbol)
+
+
+def get_original_csg_from_file(path: str, start_symbol: str = None) -> CFG:
+    """
+    Gets Context Free Grammar equivalent to file text representation of CFG.
+
+    Parameters
+    ----------
+    path: str
+        A path to file containing text representation of CFG with rules:
+        The structure of a production is: head -> body_1 | body_2 | … | body_n
+        A variable (or non terminal) begins by a capital letter
+        A terminal begins by a non-capital character
+        Terminals and Variables are separated by spaces
+        An epsilon symbol can be represented by epsilon, $, ε, ϵ or Є
+    start_symbol: str, default = None
+        An axiom for CFG
+        If not specified, 'S' will be used
+
+    Returns
+    -------
+    CNF:
+        Context Free Grammar in Chomsky Normal Form equivalent to
+        file text representation of CFG
+    Raises
+    ------
+    OSError:
+        If there was an error while working with file
+    ValueError:
+        If file text is not satisfied to the rules
+    """
+
+    if start_symbol is None:
+        start_symbol = "S"
+
+    __check_path(path)
+
+    with open(path, "r") as file:
+        cfg_str = file.read()
+    cfg = CFG.from_text(cfg_str, Variable(start_symbol))
+    return cfg
+
+
+def __check_path(path: str) -> None:
+    """
+    Checks whether path is representing a non-empty file with txt extension.
+
+    Parameters
+    ----------
+    path: str
+        A path to file containing text representation of CFG
+
+    Raises
+    ------
+    OSError:
+        If file does not exist or its extension is not txt or it is empty.
+    """
+    if not os.path.exists(path):
+        raise OSError("Wrong file path specified: file is not exists")
+    if not path.endswith(".txt"):
+        raise OSError("Wrong file path specified: *.txt is required")
+    if os.path.getsize(path) == 0:
+        raise OSError("Wrong file path specified: file is empty")
+
+
+def get_cnf_from_text(cfg_text: str, start_symbol: str = None) -> CFG:
+    """
+    Get context Free Grammar in Chomsky Normal Form (more strict case of
+    the Weak Chomsky Normal Form, which can be weakened to it through product changes)
+    equivalent to file text representation of CFG.
+
+    Parameters
+    ----------
+    cfg_text: str
+        Text representation of CFG with rules:
+        The structure of a production is: head -> body1 | body2 | … | bodyn
+        A variable (or non terminal) begins by a capital letter
+        A terminal begins by a non-capital character
+        Terminals and Variables are separated by spaces
+        An epsilon symbol can be represented by epsilon, $, ε, ϵ or Є
+    start_symbol: str, default = None
+        An axiom for CFG
+        If not specified, 'S' will be used
+    Returns
+    -------
+    CNF:
+        Context Free Grammar in Chomsky Normal Form equivalent to
+        file text representation of CFG
+    Raises
+    ------
+    ValueError:
+        If file text is not satisfied to the rules
+    """
+
+    if start_symbol is None:
+        start_symbol = "S"
+
+    cfg = CFG.from_text(cfg_text, Variable(start_symbol))
+    cnf = cfg.to_normal_form()
+
+    return cnf
+
+
+def get_wcnf_from_text(cfg_text: str, start_symbol: str = None) -> CFG:
+    """
+    Get context Free Grammar in Weak Chomsky Normal Form
+    equivalent to file text representation of CFG.
+
+    Parameters
+    ----------
+    cfg_text: str
+        Text representation of CFG with rules:
+        The structure of a production is: head -> body1 | body2 | … | bodyn
+        A variable (or non terminal) begins by a capital letter
+        A terminal begins by a non-capital character
+        Terminals and Variables are separated by spaces
+        An epsilon symbol can be represented by epsilon, $, ε, ϵ or Є
+    start_symbol: str, default = None
+        An axiom for CFG
+        If not specified, 'S' will be used
+    Returns
+    -------
+    CNF:
+        Context Free Grammar in Chomsky Normal Form equivalent to
+        file text representation of CFG
+    Raises
+    ------
+    ValueError:
+        If file text is not satisfied to the rules
+    """
+
+    if start_symbol is None:
+        start_symbol = "S"
+
+    cfg = CFG.from_text(cfg_text, Variable(start_symbol))
+
+    wcnf = (
+        cfg.remove_useless_symbols()
+        .eliminate_unit_productions()
+        .remove_useless_symbols()
+    )
+
+    new_productions = wcnf._get_productions_with_only_single_terminals()
+    new_productions = wcnf._decompose_productions(new_productions)
+
+    return CFG(start_symbol=wcnf.start_symbol, productions=set(new_productions))
+
+
+def __check_epsilons(
+    reachable_symbols: AbstractSet[Variable],
+    productions_old: AbstractSet[Production],
+    productions_nf: AbstractSet[Production],
+):
+    """
+    Test whether all epsilons in reachable variables from initial grammar are present in given normal form
+
+    Parameters
+    ----------
+    reachable_symbols: AbstractSet[Variable]
+        Set of variables in cfg_nf
+    productions_old: AbstractSet[Production]
+        Old set of productions
+    productions_nf: AbstractSet[Production]
+
+    Returns
+    -------
+    bool:
+        true if all epsilons in reachable variables from initial grammar are present in given normal form
+        false otherwise
+    """
+    productions_old_with_epsilon = set(
+        filter(
+            lambda prod: prod.head in reachable_symbols and not prod.body,
+            productions_old,
+        )
+    )
+    productions_nf_with_epsilon = set(
+        filter(lambda prod: not prod.body, productions_nf)
+    )
+    for production in productions_old_with_epsilon:
+        if production not in productions_nf_with_epsilon:
+            return False
+    return True
+
+
+def is_wcnf(cfg_nf: CFG, cfg_old: CFG) -> bool:
+    """
+    Test whether given cfg_nf is in Minimal Weakened Chomsky Normal Form
+    The rules are:
+    (1) A -> BC, where A, B, C in Variables
+    (2) A -> a, where A in Variables, a in Terminals
+    (3) A -> epsilon, where A in Variables
+    It is also checked whether every reachable epsilon production from original grammar is present in WNCF
+
+    Parameters
+    ----------
+    cfg_nf:
+        CFG to be checked
+    cfg_old:
+        Old version of CFG
+
+    Returns
+    -------
+    bool:
+        true if cfg_nf is in Minimal Weakened Chomsky Normal Form
+        false otherwise
+    """
+    for production in cfg_nf.productions:
+        body = production.body
+        if not (
+            # check (1)
+            (len(body) <= 2 and all(map(lambda x: x in cfg_nf.variables, body)))
+            # check (2)
+            or (len(body) == 1 and body[0] in cfg_nf.terminals)
+            # check (3)
+            or (not body)
+        ) or not __check_epsilons(
+            cfg_nf.variables, cfg_old.productions, cfg_nf.productions
+        ):
+            return False
+    return True
+
+
+def cfg_to_ecfg(cfg: CFG) -> ECFG:
+    """
+    This function converts a CFG to an Extended CFG
+
+    Parameters
+    ---------
+    cfg: CFG
+        CFG to convert
+
+    Returns
+    -------
+    ECFG:
+        Extended CFG from CFG
+    """
+    productions = dict()
+
+    for p in cfg.productions:
+        body = Regex(" ".join(cfg_obj.value for cfg_obj in p.body) if p.body else "$")
+        if p.head not in productions:
+            productions[p.head] = body
+        else:
+            productions[p.head] = productions.get(p.head).union(body)
+
+    ecfg_productions = [
+        ECFGProduction(head, body) for head, body in productions.items()
+    ]
+
+    return ECFG(
+        variables=cfg.variables,
+        start_symbol=cfg.start_symbol,
+        productions=ecfg_productions,
+    )

--- a/project/ecfg_utils.py
+++ b/project/ecfg_utils.py
@@ -3,9 +3,10 @@ from typing import AbstractSet, Iterable
 from pyformlang.cfg import Variable
 from pyformlang.regular_expression import Regex
 
-__all__ = ["ECFG", "InvalidECFGFormatException", "ECFGProduction"]
+__all__ = ["ECFG", "InvalidECFGException", "ECFGProduction", "ecfg_to_rsm"]
 
-from project import RSM, Box, regex_to_min_dfa
+from project import regex_to_min_dfa
+from project.rsm_utils import Box, RSM
 
 
 class ECFGProduction:
@@ -36,8 +37,23 @@ class ECFGProduction:
         return self._body
 
 
-class InvalidECFGFormatException(Exception):
-    pass
+class InvalidECFGException(Exception):
+    """
+    Exception raised for errors in the ECFG format.
+    Extended CFG:
+        - There is exactly one rule for each non-terminal.
+        - One line contains exactly one rule.
+        - Rule is non-terminal and regex over terminals and non-terminals accepted by pyformlang, separated by '->'.
+          For example: S -> a | b * S
+
+    Attributes
+    ----------
+    message: str
+        Explanation of the error
+    """
+
+    def __init__(self, message: str):
+        self.message = message
 
 
 class ECFG:
@@ -118,7 +134,7 @@ class ECFG:
 
             production_objects = line.split("->")
             if len(production_objects) != 2:
-                raise InvalidECFGFormatException(
+                raise InvalidECFGException(
                     "There should only be one production per line."
                 )
 
@@ -126,7 +142,7 @@ class ECFG:
             head = Variable(head_text.strip())
 
             if head in variables:
-                raise InvalidECFGFormatException(
+                raise InvalidECFGException(
                     "There should only be one production for each variable."
                 )
 

--- a/project/ecfg_utils.py
+++ b/project/ecfg_utils.py
@@ -1,0 +1,178 @@
+from typing import AbstractSet, Iterable
+
+from pyformlang.cfg import Variable
+from pyformlang.regular_expression import Regex
+
+__all__ = ["ECFG", "InvalidECFGFormatException", "ECFGProduction"]
+
+from project import RSM, Box, regex_to_min_dfa
+
+
+class ECFGProduction:
+    """
+    This class represents a production of a ECFG
+
+    Attributes
+    ----------
+    head: Variable
+        head of production
+    body: Regex
+        body of production represented by regex
+    """
+
+    def __init__(self, head: Variable, body: Regex):
+        self._head = head
+        self._body = body
+
+    def __str__(self):
+        return str(self.head) + " -> " + str(self.body)
+
+    @property
+    def head(self) -> Variable:
+        return self._head
+
+    @property
+    def body(self) -> Regex:
+        return self._body
+
+
+class InvalidECFGFormatException(Exception):
+    pass
+
+
+class ECFG:
+    """
+    This class represents a Extended CFG.
+    Extended CFG:
+        - There is exactly one rule for each non-terminal.
+        - One line contains exactly one rule.
+        - Rule is non-terminal and regex over terminals and non-terminals accepted by pyformlang, separated by '->'.
+          For example: S -> a | b * S
+
+    Attributes
+    ----------
+    variables: AbstractSet[Variable]
+        Set of variables of ECFG
+    start_symbol: Variable
+        Start symbol of ECFG
+    productions: Iterable[ECFGProduction]
+        Collection containing productions of ECFG
+    """
+
+    def __init__(
+        self,
+        variables: AbstractSet[Variable] = None,
+        start_symbol: Variable = None,
+        productions: Iterable[ECFGProduction] = None,
+    ):
+        self._variables = variables or set()
+        self._start_symbol = start_symbol
+        self._productions = productions or set()
+
+    @property
+    def variables(self) -> AbstractSet[Variable]:
+        return self._variables
+
+    @property
+    def productions(self) -> AbstractSet[ECFGProduction]:
+        return self._productions
+
+    @property
+    def start_symbol(self) -> Variable:
+        return self._start_symbol
+
+    def to_text(self) -> str:
+        """
+        Get a string representation of CFG
+
+        Returns
+        -------
+        str:
+            String representation
+        """
+        return "\n".join(str(p) for p in self.productions)
+
+    @classmethod
+    def from_text(cls, text, start_symbol=Variable("S")) -> "ECFG":
+        """
+        Read an ECFG from text
+
+        Parameters
+        ----------
+        text: str
+            Input text
+        start_symbol: Variable
+            Start symbol of ECFG
+
+        Raises
+        ------
+        InvalidECFGFormatException:
+            If there is a problem with ECFG format in text
+        """
+        variables = set()
+        productions = set()
+        for line in text.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+
+            production_objects = line.split("->")
+            if len(production_objects) != 2:
+                raise InvalidECFGFormatException(
+                    "There should only be one production per line."
+                )
+
+            head_text, body_text = production_objects
+            head = Variable(head_text.strip())
+
+            if head in variables:
+                raise InvalidECFGFormatException(
+                    "There should only be one production for each variable."
+                )
+
+            variables.add(head)
+            body = Regex(body_text.strip())
+            productions.add(ECFGProduction(head, body))
+
+        return ECFG(
+            variables=variables, start_symbol=start_symbol, productions=productions
+        )
+
+    @classmethod
+    def from_file(cls, path: str, start_symbol: str = "S") -> "ECFG":
+        """
+        Read an ECFG from file
+
+        Parameters
+        ----------
+        path: str
+            Path to file containing ECFG
+        start_symbol: Variable
+            Start symbol of ECFG
+
+        Raises
+        ------
+        InvalidECFGFormatException:
+            If there is a problem with ECFG format in file text
+        """
+
+        with open(path) as f:
+            return ECFG.from_text(f.read(), start_symbol=Variable(start_symbol))
+
+
+def ecfg_to_rsm(ecfg: ECFG) -> RSM:
+    """
+    Converts an ECFG to a Recursive State Machine
+
+    Parameters
+    ----------
+    ecfg: ECFG
+        Input Extended CFG to convert
+
+    Returns
+    -------
+    RSM:
+        Recursive state machine from ECFG.
+    """
+    boxes = [Box(p.head, regex_to_min_dfa(p.body)) for p in ecfg.productions]
+    return RSM(start_symbol=ecfg.start_symbol, boxes=boxes)

--- a/project/regex.py
+++ b/project/regex.py
@@ -1,10 +1,10 @@
 from pyformlang.finite_automaton import DeterministicFiniteAutomaton
 from pyformlang.regular_expression import Regex
 
-__all__ = ["regex_to_min_dfa"]
+__all__ = ["regex_str_to_min_dfa", "regex_to_min_dfa"]
 
 
-def regex_to_min_dfa(regex_str: str) -> DeterministicFiniteAutomaton:
+def regex_str_to_min_dfa(regex_str: str) -> DeterministicFiniteAutomaton:
     """
     Gets a string representation of regular expression and builds equivalent Deterministic Finite Automaton
 
@@ -24,6 +24,31 @@ def regex_to_min_dfa(regex_str: str) -> DeterministicFiniteAutomaton:
         If there is wrong form of string representation of regular expression
     """
     regex = Regex(regex_str)
+    enfa = regex.to_epsilon_nfa()
+    dfa = enfa.to_deterministic()
+    dfa_min = dfa.minimize()
+    return dfa_min
+
+
+def regex_to_min_dfa(regex: Regex) -> DeterministicFiniteAutomaton:
+    """
+    Gets a regular expression and builds equivalent Deterministic Finite Automaton
+
+    Parameters
+    ----------
+    regex: Regex
+        Regular expression
+
+    Returns
+    -------
+    DeterministicFiniteAutomaton
+        Deterministic Finite Automaton, which is equivalent to given regular expression
+
+    Raises
+    ------
+    MisformedRegexError
+        If there is wrong form of string representation of regular expression
+    """
     enfa = regex.to_epsilon_nfa()
     dfa = enfa.to_deterministic()
     dfa_min = dfa.minimize()

--- a/project/regex.py
+++ b/project/regex.py
@@ -1,7 +1,7 @@
 from pyformlang.finite_automaton import DeterministicFiniteAutomaton
 from pyformlang.regular_expression import Regex
 
-__all__ = ["regex_str_to_min_dfa", "regex_to_min_dfa"]
+__all__ = ["regex_str_to_min_dfa", "regex_to_min_dfa", "check_regex_equality"]
 
 
 def regex_str_to_min_dfa(regex_str: str) -> DeterministicFiniteAutomaton:
@@ -53,3 +53,21 @@ def regex_to_min_dfa(regex: Regex) -> DeterministicFiniteAutomaton:
     dfa = enfa.to_deterministic()
     dfa_min = dfa.minimize()
     return dfa_min
+
+
+def check_regex_equality(r1: Regex, r2: Regex):
+    """
+    Check whether regex r1 is equivalent to regex r2 (their languages are equal)
+    Parameters
+    ----------
+    r1: Regex
+        first regex
+    r2: Regex
+        second regex
+    Returns
+    -------
+    bool:
+        true if r1 is equivalent to r2
+        false otherwise
+    """
+    return regex_to_min_dfa(r1).is_equivalent_to(regex_to_min_dfa(r2))

--- a/project/rpq.py
+++ b/project/rpq.py
@@ -34,7 +34,7 @@ def rpq(
     graph_bm = BooleanMatrices.from_automaton(
         graph_to_nfa(graph, start_nodes, final_nodes)
     )
-    query_bm = BooleanMatrices.from_automaton(regex_to_min_dfa(str(query)))
+    query_bm = BooleanMatrices.from_automaton(regex_to_min_dfa(query))
 
     intersected_bm = graph_bm.intersect(query_bm)
     intersected_start_states = intersected_bm.get_start_states()

--- a/project/rsm_utils.py
+++ b/project/rsm_utils.py
@@ -1,0 +1,102 @@
+from typing import Iterable
+
+from pyformlang.cfg import Variable
+from pyformlang.finite_automaton import DeterministicFiniteAutomaton
+
+__all__ = ["RSM", "minimize_rsm", "Box"]
+
+
+class Box:
+    """
+    This class represents a box for recursive state machine
+
+    Parameters
+    ----------
+    variable : Variable
+       variable of RSM
+    dfa : DeterministicFiniteAutomaton
+        Deterministic Finite Automaton for variable
+    """
+
+    def __init__(
+        self, variable: Variable = None, dfa: DeterministicFiniteAutomaton = None
+    ):
+        self._dfa = dfa
+        self._variable = variable
+
+    def __eq__(self, other: "Box"):
+        return self._variable == other._variable and self._dfa.is_equivalent_to(
+            other._dfa
+        )
+
+    def minimize(self):
+        """
+        Minimize dfa in Box
+
+        Returns
+        -------
+            None
+        """
+        self._dfa = self._dfa.minimize()
+
+    @property
+    def dfa(self):
+        return self._dfa
+
+    @property
+    def variable(self):
+        return self._variable
+
+
+class RSM:
+    """
+    This class represents a recursive state machine (RSM).
+
+    Parameters
+    ----------
+    start_symbol : Variable
+        A start symbol for automaton
+    boxes : Iterable[Box]
+        A finite collection of boxes
+    """
+
+    def __init__(
+        self,
+        start_symbol: Variable,
+        boxes: Iterable[Box],
+    ):
+        self._start_symbol = start_symbol
+        self._boxes = boxes
+
+    @property
+    def boxes(self):
+        return self._boxes
+
+    @property
+    def start_symbol(self):
+        return self._start_symbol
+
+    def set_start_symbol(self, start_symbol: Variable):
+        self._start_symbol = start_symbol
+
+    def minimize(self):
+        for box in self._boxes:
+            box.minimize()
+        return self
+
+
+def minimize_rsm(rsm: RSM) -> RSM:
+    """
+    Function to minimize given RSM
+
+    Parameters
+    ----------
+        rsm: RSM
+            RSM to minimize
+
+    Returns
+    -------
+        RSM:
+            Minimized RSM
+    """
+    return rsm.minimize()

--- a/tests/test_ecfg.py
+++ b/tests/test_ecfg.py
@@ -46,7 +46,7 @@ def test_ecfg_productions(cfg, exp_ecfg_productions):
             regex_to_min_dfa(exp_ecfg_productions[p.head])
         )
         for p in ecfg_productions
-    ) and len(ecfg_productions) == len(ecfg_productions)
+    ) and len(ecfg_productions) == len(exp_ecfg_productions)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_ecfg.py
+++ b/tests/test_ecfg.py
@@ -1,0 +1,139 @@
+import pytest
+from pyformlang.cfg import Variable, CFG
+from pyformlang.regular_expression import Regex
+
+from project import regex_to_min_dfa, check_regex_equality
+from project.cfg_utils import cfg_to_ecfg
+from project.ecfg_utils import ecfg_to_rsm, ECFG, InvalidECFGException
+from project.rsm_utils import Box
+
+
+@pytest.mark.parametrize(
+    "cfg, exp_ecfg_productions",
+    [
+        (
+            """
+                S -> epsilon
+                """,
+            {Variable("S"): Regex("$")},
+        ),
+        (
+            """
+                S -> a S b S
+                S -> epsilon
+                """,
+            {Variable("S"): Regex("(a S b S) | $")},
+        ),
+        (
+            """
+                S -> i f ( C ) t h e n { ST } e l s e { ST }
+                C -> t r u e | f a l s e
+                ST -> p a s s | S
+                """,
+            {
+                Variable("S"): Regex("i f ( C ) t h e n { ST } e l s e { ST }"),
+                Variable("C"): Regex("t r u e | f a l s e"),
+                Variable("ST"): Regex("p a s s | S"),
+            },
+        ),
+    ],
+)
+def test_ecfg_productions(cfg, exp_ecfg_productions):
+    ecfg = cfg_to_ecfg(CFG.from_text(cfg))
+    ecfg_productions = ecfg.productions
+    assert all(
+        regex_to_min_dfa(p.body).is_equivalent_to(
+            regex_to_min_dfa(exp_ecfg_productions[p.head])
+        )
+        for p in ecfg_productions
+    ) and len(ecfg_productions) == len(ecfg_productions)
+
+
+@pytest.mark.parametrize(
+    "text_ecfg, expected_productions",
+    [
+        ("""""", []),
+        (
+            """S -> a S b S | $""",
+            {
+                Variable("S"): Regex("a S b S | $"),
+            },
+        ),
+        ("""S -> (a | b)* c""", {Variable("S"): Regex("(a | b)* c")}),
+        (
+            """
+         S -> (a (S | $) b)*
+         A -> a b c
+         """,
+            {
+                Variable("S"): Regex("(a (S | $) b)*"),
+                Variable("A"): Regex("a b c"),
+            },
+        ),
+    ],
+)
+def test_read_from_text(text_ecfg, expected_productions):
+    ecfg = ECFG.from_text(text_ecfg)
+    assert len(ecfg.productions) == len(expected_productions) and all(
+        check_regex_equality(p.body, expected_productions[p.head])
+        for p in ecfg.productions
+    )
+
+
+@pytest.mark.parametrize(
+    "text_cfg",
+    [
+        """S -> B -> C""",
+        """A -> b B -> a""",
+        """
+        S -> a S b S
+        A -> B ->
+        """,
+    ],
+)
+def test_more_than_one_production_per_line(text_cfg):
+    with pytest.raises(InvalidECFGException):
+        ECFG.from_text(text_cfg)
+
+
+@pytest.mark.parametrize(
+    "text_cfg",
+    [
+        """
+        S -> B
+        S -> A
+        """,
+        """
+        A -> b
+        B -> a
+        A -> c""",
+    ],
+)
+def test_more_than_one_production_with_line(text_cfg):
+    with pytest.raises(InvalidECFGException):
+        ECFG.from_text(text_cfg)
+
+
+@pytest.mark.parametrize(
+    """ecfg_text""",
+    (
+        """
+        """,
+        """
+        S -> $
+        """,
+        """
+        S -> a S b S
+        B -> B B
+        C -> A B C
+        """,
+    ),
+)
+def test_boxes_regex_equality(ecfg_text):
+    ecfg = ECFG.from_text(ecfg_text)
+    rsm = ecfg_to_rsm(ecfg)
+    act_start_symbol = ecfg.start_symbol
+    exp_start_symbol = rsm.start_symbol
+    exp_boxes = [Box(p.head, regex_to_min_dfa(p.body)) for p in ecfg.productions]
+    act_boxes = rsm.boxes
+    return act_start_symbol == exp_start_symbol and act_boxes == exp_boxes

--- a/tests/test_regex.py
+++ b/tests/test_regex.py
@@ -3,13 +3,13 @@ from typing import Iterable, List
 import pytest
 from pyformlang.regular_expression import MisformedRegexError
 
-from project.regex import regex_to_min_dfa
+from project.regex import regex_str_to_min_dfa
 from pyformlang.finite_automaton import Symbol, DeterministicFiniteAutomaton, State
 
 
 def test_regex_to_dfa_deterministic():
     regex1 = "11(10)*"
-    dfa = regex_to_min_dfa(regex1)
+    dfa = regex_str_to_min_dfa(regex1)
     assert dfa.is_deterministic()
 
 
@@ -52,7 +52,7 @@ def test_regex_to_dfa_accept(
     expected_words: List[Iterable[Symbol]],
     unexpected_words: List[Iterable[Symbol]],
 ):
-    dfa = regex_to_min_dfa(regex)
+    dfa = regex_str_to_min_dfa(regex)
     assert all(dfa.accepts(expected_word) for expected_word in expected_words) and all(
         (not dfa.accepts(unexpected_word)) for unexpected_word in unexpected_words
     )
@@ -60,30 +60,11 @@ def test_regex_to_dfa_accept(
 
 def test_wrong_regex():
     with pytest.raises(MisformedRegexError):
-        regex_to_min_dfa("*|wrong|*")
+        regex_str_to_min_dfa("*|wrong|*")
 
 
-def test_get_min_dfa() -> None:
-    expected_dfa = DeterministicFiniteAutomaton()
+def test_is_minimal():
+    dfa = regex_str_to_min_dfa("1* 0 0")
+    dfa_minimal = dfa.minimize()
 
-    state_0 = State(0)
-    state_1 = State(1)
-
-    symbol_a = Symbol("a")
-    symbol_l = Symbol("l")
-
-    expected_dfa.add_start_state(state_0)
-
-    expected_dfa.add_final_state(state_0)
-    expected_dfa.add_final_state(state_1)
-
-    expected_dfa.add_transition(state_0, symbol_a, state_0)
-    expected_dfa.add_transition(state_0, symbol_l, state_1)
-
-    expected_dfa.add_transition(state_1, symbol_l, state_1)
-
-    actual_dfa = regex_to_min_dfa("a* l*")
-
-    assert expected_dfa.is_equivalent_to(actual_dfa) and len(actual_dfa.states) == len(
-        expected_dfa.states
-    )
+    assert dfa.is_equivalent_to(dfa_minimal)


### PR DESCRIPTION
## Расширенные контекстно-свободные грамматики (ECFG)

В дополнение к существующему в pyformalng формату описания КС грамматик зафиксируем следующий формат.
- Для каждого нетерминала существует ровно одно правило.
- На одной строке содержится ровно одно правило.
- Правило --- это нетерминал и регулярное выражение над терминалами и нетерминалами, принимаемое pyformalng, разделенные ``` -> ```. Например: ``` S -> a | b* S ```

Будем называть данный формат расширенными контекстно-свободными грамматиками (Extended Context-Free Grammars, ECFG).

## Задача

- [x] Реализовать тип для представления рекурсивных конечных автоматов. В качестве составных частей можно использовать типы из pyformlang (например, [конечные автоматы](https://pyformlang.readthedocs.io/en/latest/usage.html#finite-automata)). При проектировании этого типа необходимо помнить, что рекурсивные конечные автоматы будут использоваться в алгоритмах КС достижимости, основанных на линейной алгебре, а значит необходимо будет строить матрицы смежности. Здесь могут быть полезны результаты домашних работ по конечным автоматам.
- [x] Реализовать внутреннее представление для ECFG, пригодное как для дальнейшей конвертации в рекурсивный конечный автомат, так и для получения его из "внешних источников", таких, например, как преобразование из стандартного внутреннего представления КС грамматик в pyformlang.
- [x] Используя [возможности pyformlang для работы с контекстно-свободными грамматиками](https://pyformlang.readthedocs.io/en/latest/modules/context_free_grammar.html), реализовать **функцию** преобразования контекстно-свободной грамматики в стандартном формате pyformlang в ECFG.
  - Предусмотреть возможность получать исходную грамматику из различных источников. Например, прочитать из файла или получить из преобразования в ОНФХ.
- [x] Используя [возможности pyformlang для работы с контекстно-свободными грамматиками](https://pyformlang.readthedocs.io/en/latest/modules/context_free_grammar.html), [регулярными выражениями](https://pyformlang.readthedocs.io/en/latest/usage.html#regular-expression) и [конечными автоматами](https://pyformlang.readthedocs.io/en/latest/usage.html#finite-automata), реализовать **функцию** преобразования контекстно-свободной грамматики в ECFG в рекурсивный конечный автомат.
  - Предусмотреть возможность получать исходную грамматику из различных источников. Например, прочитать из файла, прочитать из строковой переменной, получить как результат работы какой-либо другой процедуры.
- [x] Реализовать **функцию** минимизации рекурсивного конечного автомата. Здесь под минимизацией понимается минимизация автомата для каждого нетерминала как конечного автомата над смешанным алфавитом.
- [x] Добавить необходимые тесты.